### PR TITLE
makefile: Change from bash script to Makefile system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-default: run
 
 ## Defines
 SRC     = cmd/bandwidth/*.go
+GOPKG   = github.com/ErebusBat/mikrotik/cmd/bandwidth
 EXEFILE = bandwidth
 
 ## Input and Output Variables
@@ -13,7 +13,8 @@ DATE_STAMP := $(shell date +%Y%m%d-%H%M%S)
 BUILDTAG   = $(DATE_STAMP)-$(GIT_VER)
 PLATARCH   = $(GOOS)-$(GOARCH)
 OUTDIR     = bin/$(BUILDTAG)/$(PLATARCH)
-GOMAKE     = GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o "$(OUTDIR)/$(EXEFILE)$(EXEEXT)" -ldflags "-X main.BUILD_TAG $(BUILDTAG)" $(SRC)
+GOLDFLAGS  = -ldflags '-X main.BUILD_TAG $(BUILDTAG)'
+GOMAKE     = GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o "$(OUTDIR)/$(EXEFILE)$(EXEEXT)" $(GOLDFLAGS) $(SRC)
 ZIPFILE    = $(OUTDIR)/../$(PLATARCH)-$(BUILDTAG).zip
 ZIPCMD     = zip -j "$(ZIPFILE)" "$(OUTDIR)/$(EXEFILE)$(EXEEXT)"
 
@@ -21,16 +22,28 @@ ZIPCMD     = zip -j "$(ZIPFILE)" "$(OUTDIR)/$(EXEFILE)$(EXEEXT)"
 # Generic Targets
 ################################################################################
 
+default: build
 
-.PHONY: default mac
+# .PHONY: default mac
+# .PHONY: build
 
-.PHONY: build
 build: mac
 
 clean:
 	rm -dfr bin/*
+	go clean -i -x
+
+uninstall:
+	go clean -i -x $(GOPKG)
 
 all: mac win linux
+
+deps:
+	go get -u -f $(GOPKG)
+
+install: deps goinst
+goinst:
+	go install $(GOLDFLAGS) $(GOPKG)
 
 ################################################################################
 # Mac OSX Targets

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env zsh
-go build -ldflags "-X main.BUILD_TAG $(git describe --always --dirty)" cmd/bandwidth/*.go

--- a/cmd/bandwidth/bandwidth.go
+++ b/cmd/bandwidth/bandwidth.go
@@ -18,6 +18,7 @@ const (
 	unknown cliAction = iota
 	monitorBandwidth
 	printInterfaces
+	printVersion
 )
 
 // Set during build with
@@ -47,6 +48,8 @@ func main() {
 		app.actionMonitorBandwidth()
 	case printInterfaces:
 		app.actionPrintKnownInterfaces()
+	case printVersion:
+		// Version already
 	default:
 		log.Fatalf("Unknown action %#v?!?! ", app.action)
 	}
@@ -103,6 +106,9 @@ func parseConfig() *AppConfig {
 		host, community string
 	)
 	cfg := new(AppConfig)
+
+	var isVersion bool = false
+
 	cfg.action = monitorBandwidth
 	flag.StringVar(&host, "h", "127.0.0.7", "Mikrotik IP")
 	flag.StringVar(&community, "c", "public", "SNMP Community Name")
@@ -112,7 +118,14 @@ func parseConfig() *AppConfig {
 
 	// Non operational flags
 	flag.BoolVar(&cfg.dumpInterfaces, "list", false, "Lists all known interfaces and exits")
+	flag.BoolVar(&isVersion, "v", false, "Report version and exit")
 	flag.Parse()
+
+	if isVersion {
+		cfg.action = printVersion
+		return cfg
+	}
+
 	cfg.Routerboard = snmp.Connect(host, community)
 
 	// Print RB banner (so it is on all output)


### PR DESCRIPTION
This is much more flexible system, with the following (main) tasks:
- build (mac64, default)
- clean
- install
- uninstall
- all (win32/64, linux32/64, mac64)

The version / `main.BUILD_TAG` will be composed like:

```
PLATFORM-ARCH-YYYYMMDD-HHMMSS-SHA1
windows-amd64-20150317-082841-da51745
```

This can be viewed in the header output of the command or (`-v`)

There are other specific or utility commands, the most
notable is `goinst`, which is invoked as the last step of `install`.

This allows us to test / use `go install` with a build tag without
updating dependancies. This is needed when building the project from
 a different branch because an update (`go get -u`) will switch back
 to the master branch.
